### PR TITLE
exit on no app configured

### DIFF
--- a/bin/avoscloud
+++ b/bin/avoscloud
@@ -731,10 +731,12 @@ function logProjectHome() {
     console.log('[INFO]: Cloud Code Project Home Directory: ' + color.green(CLOUD_PATH));
     var apps = readAppsSync();
     var currApp = getCurrApp();
-    if (apps[currApp])
+    if (apps[currApp]) {
         console.log('[INFO]: Current App: %s', color.red(currApp + ' ' + getAppId(currApp)));
-    else
+    } else {
         console.warn('[INFO]: You are not in a app.Please checkout <app>');
+        process.exit(1);
+    }
 }
 
 sendStats(CMD);


### PR DESCRIPTION
execute `avoscloud` on non app folder will raise this error:

```
➜  ~  avoscloud
[INFO]: Cloud Code Project Home Directory: /Users/asaka/
[INFO]: You are not in a app.Please checkout <app>

/usr/local/lib/node_modules/avoscloud-code/bin/avoscloud:559
        throw "Can't find a valid app to execute command '" + CMD + "'.";
                                                                  ^
Can't find a valid app to execute command 'undefined'.
```

should do `exit(1)` on this branch.
