### PR TITLE
deploy by zip package, tar package permissions err on windows

### DIFF
--- a/bin/avoscloud
+++ b/bin/avoscloud
@@ -14,6 +14,7 @@ var exec = require('child_process').exec;
 var fstream = require('fstream'),
     tar = require('tar'),
     zlib = require('zlib');
+var archiver = require('archiver');
 var os = require('os');
 var request = require('request');
 var _s = require('underscore.string'),
@@ -203,65 +204,54 @@ function uploadFile(localFile, props, cb, retry, retries) {
 function deployLocalCloudCode(cloudPath) {
     initMasterKey(function() {
         console.log("Compress cloud code files...");
-        var file = path.join(TMP_DIR, new Date().getTime() + '.tar.gz');
-        var count = 0;
+        var file = path.join(TMP_DIR, new Date().getTime() + '.zip');
+        var output = fs.createWriteStream(file);
+        var archive = archiver('zip');
 
-        fstream.Reader({
-                'root': cloudPath,
-                'path': cloudPath,
-                'type': 'Directory',
-                filter: function() {
-                    count++;
-                    if (count == 1) {
-                        //the root folder.
-                        return true;
-                    }
-                    var filePath = path.normalize(this.path);
-                    //only compress legal files and directories.
-                    return _.find(['cloud', 'public', 'config', 'package.json'], function(folder) {
-                        return _s.startsWith(filePath, cloudPath + folder);
-                    });
+        output.on('close', function() {
+            console.log("Wrote compressed file " + file + ' ...');
+            //upload file to cloud code
+            console.log("Begin to upload cloud code files...");
+            var key = util.guid() + '.zip';
+            uploadFile(file, {
+                key: key,
+                name: file,
+                mime_type: 'application/zip, application/octet-stream'
+            }, function(err, url, fileId) {
+                if (err) {
+                    console.error("Upload cloud code files failed with '%j'", err.responseText);
+                    destroyFile(fileId);
+                    process.exit(1);
+                } else {
+                    console.log("Upload cloud code files successfully. Begin to deploy...");
+                    //notify avoscloud platform to fetch new deployment.
+                    util.requestCloud('functions/deploy/command', {
+                        revision: url,
+                        fileId: fileId,
+                        log: program.log
+                    }, 'POST', {
+                        success: function(resp) {
+                            console.log("Congrats! Deploy cloud code successfully.");
+                            queryStatus();
+                        },
+                        error: function(err) {
+                            console.log("Sorry, try to deploy cloud code failed with '%s'", err.responseText);
+                        }
+                    }, true);
                 }
-            }).pipe(tar.Pack({
-                path: '.'
-            }))
-            .pipe(zlib.Gzip())
-            .pipe(fstream.Writer({
-                'path': file
-            }))
-            .on('close', function() {
-                console.log("Wrote compressed file " + file + ' ...');
-                //upload file to cloud code
-                console.log("Begin to upload cloud code files...");
-                var key = util.guid() + '.tar.gz';
-                uploadFile(file, {
-                    key: key,
-                    name: file,
-                    mime_type: 'application/x-gzip, application/octet-stream'
-                }, function(err, url, fileId) {
-                    if (err) {
-                        console.error("Upload cloud code files failed with '%j'", err.responseText);
-                        destroyFile(fileId);
-                        process.exit(1);
-                    } else {
-                        console.log("Upload cloud code files successfully. Begin to deploy...");
-                        //notify avoscloud platform to fetch new deployment.
-                        util.requestCloud('functions/deploy/command', {
-                            revision: url,
-                            fileId: fileId,
-                            log: program.log
-                        }, 'POST', {
-                            success: function(resp) {
-                                console.log("Congrats! Deploy cloud code successfully.");
-                                queryStatus();
-                            },
-                            error: function(err) {
-                                console.log("Sorry, try to deploy cloud code failed with '%s'", err.responseText);
-                            }
-                        }, true);
-                    }
-                }, false);
-            });
+            }, false);
+        });
+
+        archive.on('error', function(err) {
+            console.error("Compress cloud code files failed with '%s'", err);
+            process.exit(1);
+        });
+
+        archive.pipe(output);
+        archive.bulk([
+          { src: ['package.json', 'cloud/**', 'config/**', 'public/**']}
+        ]);
+        archive.finalize();
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,76 +1,74 @@
 {
-    "name": "avoscloud-code",
-    "version": "0.5.1",
-    "main": "./lib/cloud_code.js",
-    "description": "AVOS Cloud Code SDK.",
-    "repository": {
-        "type": "git",
-        "url": "git@github.com:avoscloud/avoscloud-code-command.git"
-    },
-    "keywords": [
-        "cloud",
-        "BaaS",
-        "avos",
-        "avoscloud",
-        "web-service"
-    ],
-    "bugs": {
-        "url": "https://github.com/avoscloud/avoscloud-code-command/issues"
-    },
-    "dependencies": {
-        "tar": "0.1.19",
-        "request": "2.45.0",
-        "cli-color": "0.3.2",
-        "sprintf-js": "0.0.7",
-        "fstream": "0.1.25",
-        "adm-zip": "0.4.4",
-        "commander": "2.2.0",
-        "qiniu": "6.1.5",
-        "qs": "0.6.5",
-        "cookie-signature": "1.0.1",
-        "buffer-crc32": "0.2.1",
-        "debug": "0.7.4",
-        "mime": "1.2.11",
-        "avos-express-cookie-session": "latest",
-        "iconv-lite": "0.2.11",
-        "avos-express-https-redirect": "latest",
-        "avoscloud-sdk": "latest",
-        "underscore": "1.6.0",
-        "underscore.string": "2.3.3",
-        "cron": "latest",
-        "moment": "2.7.0",
-        "express": "3.4.0",
-        "async": "0.9.0",
-        "express-ejs-layouts": "0.3.1",
-        "weibo": "0.6.9",
-        "node-qiniu": "6.1.6",
-        "mailgun": "0.4.2",
-        "mandrill": "0.1.0",
-        "xml2js": "0.4.4",
-        "stripe": "2.5.0",
-        "sendgrid": "1.0.5",
-        "rekuire": "0.1.3",
-        "ejs": "0.8.4",
-        "jade": "0.26.0",
-        "avos-lock": "latest",
-        "promptly": "0.2.0"
-    },
-
-    "bin": {
-        "avoscloud": "./bin/avoscloud"
-    },
-
-    "engines": [
-        "node >= 0.10.0"
-    ],
-
-    "devDependencies": {
-        "mocha": "1.9.0",
-        "expect.js ": "0.2.0"
-    },
-    "author": {
-        "name": "dennis zhuang",
-        "email": "xzhuang@avos.com"
-    },
-    "license": "LGPL"
+  "name": "avoscloud-code",
+  "version": "0.5.1",
+  "main": "./lib/cloud_code.js",
+  "description": "AVOS Cloud Code SDK.",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:avoscloud/avoscloud-code-command.git"
+  },
+  "keywords": [
+    "cloud",
+    "BaaS",
+    "avos",
+    "avoscloud",
+    "web-service"
+  ],
+  "bugs": {
+    "url": "https://github.com/avoscloud/avoscloud-code-command/issues"
+  },
+  "dependencies": {
+    "adm-zip": "0.4.4",
+    "archiver": "^0.13.0",
+    "async": "0.9.0",
+    "avos-express-cookie-session": "latest",
+    "avos-express-https-redirect": "latest",
+    "avos-lock": "latest",
+    "avoscloud-sdk": "latest",
+    "buffer-crc32": "0.2.1",
+    "cli-color": "0.3.2",
+    "commander": "2.2.0",
+    "cookie-signature": "1.0.1",
+    "cron": "latest",
+    "debug": "0.7.4",
+    "ejs": "0.8.4",
+    "express": "3.4.0",
+    "express-ejs-layouts": "0.3.1",
+    "fstream": "0.1.25",
+    "iconv-lite": "0.2.11",
+    "jade": "0.26.0",
+    "mailgun": "0.4.2",
+    "mandrill": "0.1.0",
+    "mime": "1.2.11",
+    "moment": "2.7.0",
+    "node-qiniu": "6.1.6",
+    "promptly": "0.2.0",
+    "qiniu": "6.1.5",
+    "qs": "0.6.5",
+    "rekuire": "0.1.3",
+    "request": "2.45.0",
+    "sendgrid": "1.0.5",
+    "sprintf-js": "0.0.7",
+    "stripe": "2.5.0",
+    "tar": "0.1.19",
+    "underscore": "1.6.0",
+    "underscore.string": "2.3.3",
+    "weibo": "0.6.9",
+    "xml2js": "0.4.4"
+  },
+  "bin": {
+    "avoscloud": "./bin/avoscloud"
+  },
+  "engines": [
+    "node >= 0.10.0"
+  ],
+  "devDependencies": {
+    "mocha": "1.9.0",
+    "expect.js ": "0.2.0"
+  },
+  "author": {
+    "name": "dennis zhuang",
+    "email": "xzhuang@avos.com"
+  },
+  "license": "LGPL"
 }


### PR DESCRIPTION
tar 文件格式在 windows 上容易出现权限错误，表现为「文件夹没有 x 权限」，导致 linux 环境解压缩会失败。改成 zip 没有问题。

服务端已经同时支持 zip 和 tar.gz 两种格式上传。
