### PR TITLE
Remove useless new line

### DIFF
--- a/lib/cloud_code.js
+++ b/lib/cloud_code.js
@@ -390,7 +390,7 @@ function requireFromFile(path, filename, watch) {
     var m = new Module();
     m.paths = module.paths;
     cache[path] = m;
-    m._compile("var AV = require('avoscloud-sdk').AV;var __production=0; \n" + src, filename);
+    m._compile("var AV = require('avoscloud-sdk').AV;var __production=0; " + src, filename);
     if (watch)
         watchFile(path, filename);
     return m.exports;


### PR DESCRIPTION
Adding new lines before user's code makes Error.stack reports wrong line number.
