### PR TITLE
加强部署失败的错误提示

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -187,8 +187,20 @@ function deployLocalCloudCode(cloudPath) {
                             queryStatus();
                         },
                         error: function(err) {
-                            console.log("Sorry, try to deploy cloud code failed with '%s'", err.responseText);
-                            process.exit(1);
+	                        try{
+		                        var eobj = JSON.parse(err.responseText);
+		                        console.log("Sorry, failed to deploy cloud code failed with error %d\n%s", eobj.code, eobj.error);
+		                        process.exit(1);
+	                        } catch(e){
+	                        }
+	                        var isHtml = /<title>([\s\S]+)<\/title>/i;
+	                        if(isHtml.test(err.responseText)){
+		                        var title = isHtml.exec(err.responseText);
+		                        console.log("Sorry, try to deploy cloud code failed with '%s'", title[0]);
+	                        } else{
+		                        console.log("Sorry, try to deploy cloud code failed with '%s'", err.responseText);
+	                        }
+	                        process.exit(1);
                         }
                     }, true);
                 }

--- a/bin/run.js
+++ b/bin/run.js
@@ -187,6 +187,11 @@ function deployLocalCloudCode(cloudPath) {
                             queryStatus();
                         },
                         error: function(err) {
+	                        if(!err.responseText){
+		                        console.log("Sorry, failed to deploy cloud code failed with error");
+		                        console.log(err)
+		                        process.exit(1);
+	                        }
 	                        try{
 		                        var eobj = JSON.parse(err.responseText);
 		                        console.log("Sorry, failed to deploy cloud code failed with error %d\n%s", eobj.code, eobj.error);
@@ -196,7 +201,7 @@ function deployLocalCloudCode(cloudPath) {
 	                        var isHtml = /<title>([\s\S]+)<\/title>/i;
 	                        if(isHtml.test(err.responseText)){
 		                        var title = isHtml.exec(err.responseText);
-		                        console.log("Sorry, try to deploy cloud code failed with '%s'", title[0]);
+		                        console.log("Sorry, try to deploy cloud code failed with '%s'", title[1]);
 	                        } else{
 		                        console.log("Sorry, try to deploy cloud code failed with '%s'", err.responseText);
 	                        }


### PR DESCRIPTION
以前显示html的时候现在显示 500 错误 （title标签内容）
预料内的错误是个json，解析并显示内容，带换行
如果出现“undefined”错误，输出resonse对象而不是responseText