### PR TITLE
bugfix: app add 命令在项目目录没有关联应用时执行会报错

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ sudo npm install -g  git+https://github.com/leancloud/avoscloud-code-command
 
 详情查看 [changelog.md](https://github.com/leancloud/avoscloud-code-command/blob/master/changelog.md)
 
+* 2015-05-28 发布 v0.7.3，修复 app add 命令在 LeanEngine 项目目录没有关联应用时执行报错的 Bug。
 * 2015-05-25 发布 v0.7.2，支持 LeanEngine Node.js 运行时项目的部署；中文化提示信息等。
 * 2015-05-16 发布 v0.7.1，修复关闭 _File 创建权限后无法本地部署云代码的 Bug。
 * 2015-05-05 发布 v0.7.0，改进部署日志和错误信息提示，增加 `--debug` 开关等。

--- a/bin/avoscloud
+++ b/bin/avoscloud
@@ -30,27 +30,24 @@ var callback = function(err){
   var exitCode = err.exitCode || 1;
   if (!err.cause) {
     console.log("错误：", err.message || err);
-    return process.exit(exitCode);
-  }
-
-  var responseText = err.cause.responseText;
-  if(!responseText){
+  } else if (!err.cause.responseText) {
     console.log("抱歉，%s 失败：%s", err.action, err.cause);
-    process.exit(exitCode);
+  } else {
+    var responseText = err.cause.responseText;
+    try{
+      var eobj = JSON.parse(responseText);
+      console.log("抱歉，%s 失败：%d\n%s", err.action, eobj.code, eobj.error);
+    } catch(e){
+      var isHtml = /<title>([\s\S]+)<\/title>/i;
+      if(isHtml.test(responseText)){
+        var title = isHtml.exec(responseText);
+        console.log("抱歉，%s 失败：'%s'", err.action, title[1]);
+      } else {
+        console.log("抱歉，%s 失败：'%s'", err.action, responseText);
+      }
+    }
   }
-  try{
-    var eobj = JSON.parse(responseText);
-    console.log("抱歉，%s 失败：%d\n%s", err.action, eobj.code, eobj.error);
-    process.exit(exitCode);
-  } catch(e){
-  }
-  var isHtml = /<title>([\s\S]+)<\/title>/i;
-  if(isHtml.test(responseText)){
-    var title = isHtml.exec(responseText);
-    console.log("抱歉，%s 失败：'%s'", err.action, title[1]);
-  } else{
-    console.log("抱歉，%s 失败：'%s'", err.action, responseText);
-  }
+  console.log("查看使用帮助：avoscloud -h");
   process.exit(exitCode);
 }
 
@@ -91,6 +88,25 @@ if(CMD) {
     case 'new':
       run.createNewProject(callback);
       break;
+    case "clear":
+      run.deleteMasterKeys();
+      callback();
+      break;
+    case "add":
+      // add <name> <app id>
+      var name = program.args[1];
+      var appId = program.args[2];
+      if (!name)
+        return exitWith("请使用：avoscloud add <name> <app id>");
+      if (!appId)
+        return exitWith("请使用：avoscloud add <name> <app id>");
+      run.addApp(name, appId);
+      callback();
+      break;
+    case "lint":
+      run.doLint();
+      callback();
+      break;
   }
 }
 
@@ -129,10 +145,6 @@ runtime.detect(CLOUD_PATH, function(err, runtimeInfo) {
         run.logProjectHome();
         run.viewCloudLog(program.lines, program.tailf, null, callback);
         break;
-      case "clear":
-        run.deleteMasterKeys();
-        callback();
-        break;
       case "upload":
         run.initAVOSCloudSDK();
         run.logProjectHome();
@@ -150,17 +162,6 @@ runtime.detect(CLOUD_PATH, function(err, runtimeInfo) {
         //app <list>
         var isList = program.args[1] == 'list';
         run.appStatus(isList);
-        callback();
-        break;
-      case "add":
-        // add <name> <app id>
-        var name = program.args[1];
-        var appId = program.args[2];
-        if (!name)
-          return exitWith("请使用：avoscloud add <name> <app id>");
-        if (!appId)
-          return exitWith("请使用：avoscloud add <name> <app id>");
-        run.addApp(name, appId);
         callback();
         break;
       case "rm":
@@ -181,10 +182,6 @@ runtime.detect(CLOUD_PATH, function(err, runtimeInfo) {
         break;
       case "cql":
         run.doCloudQuery(callback);
-        break;
-      case "lint":
-        run.doLint();
-        callback();
         break;
       default:
         program.help();

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## v0.7.3
+* 修复 app add 命令在 LeanEngine 项目目录没有关联应用时执行报错的 Bug。
+* 增加 命令执行出错时提示「查看使用帮助：avoscloud -h」
+
 ## v0.7.2
 * 支持 LeanEngine Node.js 运行时项目的部署。
 * 中文化提示信息。

--- a/latest.version
+++ b/latest.version
@@ -1,4 +1,4 @@
 {
-  "version": "0.7.2",
-  "changelog": "* 支持 LeanEngine Node.js 运行时项目的部署。\n* 中文化提示信息。\n* 修复 命令行工具无法正常退出的 Bug。* 修复 部署失败仍然提示 'Deploy cloud code successfully' 的 Bug。\n"
+  "version": "0.7.3",
+  "changelog": "* 修复 app add 命令在 LeanEngine 项目目录没有关联应用时执行报错的 Bug。\n"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avoscloud-code",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "main": "./lib/cloud_code.js",
   "description": "AVOS Cloud Code SDK.",
   "repository": {


### PR DESCRIPTION
顺便增加命令执行出错时提示「查看使用帮助：avoscloud -h」