### PR TITLE
重构 AV 对象初始化、查询并记录 appKey、运行时向程序发送 appKey

### DIFF
--- a/bin/avoscloud
+++ b/bin/avoscloud
@@ -117,7 +117,6 @@ if(CMD) {
       break;
 
     case "upload":
-      run.initAVOSCloudSDK();
       run.logProjectHome();
       if (!program.args[1]) {
         console.log("请使用：avoscloud upload <文件或目录>");
@@ -223,14 +222,14 @@ if(CMD) {
         console.log('[INFO] 因为文件变更而项目重启：', files);
     });
     if (runtimeInfo.runtime != 'cloudcode') {
-      run.initMasterKey(function(masterKey) {
+      run.initAVOSCloudSDK(function(AV) {
         var app = run.getAppSync();
         var testServerPort = parseInt(run.getPort()) + 1;
         testServer.set('leanenginePort', run.getPort());
         testServer.set('port', testServerPort);
         testServer.set('appId', app.appId);
-        testServer.set('appKey', masterKey);
-        testServer.set('masterKey', masterKey);
+        testServer.set('appKey', AV.applicationKey);
+        testServer.set('masterKey', AV.masterKey);
         console.log(color.green('提示：您可以使用 http://localhost:' + testServerPort + ' 测试 Cloud 函数'));
         testServer.listen(testServerPort);
       });

--- a/bin/cloudcodeRun.js
+++ b/bin/cloudcodeRun.js
@@ -1,6 +1,6 @@
+'use strict';
 var fs = require('fs');
 var path = require('path');
-var AV = require('avoscloud-sdk').AV;
 var run = require('./run');
 var commander = require('./commander');
 var lib = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
@@ -15,7 +15,7 @@ if (!CLOUD_PATH.match(/.*\/$/)) {
 }
 
 run.logProjectHome();
-run.initAVOSCloudSDK(function(masterKey) {
+run.initAVOSCloudSDK(function(AV) {
     require(lib + '/mock').run(CLOUD_PATH, AV, run.getPort());
     console.log("请使用浏览器打开 http://localhost:" + run.getPort() + "/avos");
 });

--- a/bin/run.js
+++ b/bin/run.js
@@ -104,13 +104,13 @@ var initMasterKey = exports.initMasterKey = function(done) {
             updateMasterKeys(currApp.appId, {
                 masterKey: masterKey,
                 appKey: appDetail.app_key
-            }, {force: true}, callback);
+            }, {force: true}, callback.bind(null, appDetail));
         });
     };
 
     updateMasterKeys(currApp.appId, {}, function(err, keys) {
         if (keys.masterKey) {
-            done = done.bind(null, keys.masterKey);
+            done = done.bind(null, keys.masterKey, keys.appKey);
 
             AV.initialize(currApp.appId, keys.masterKey);
 
@@ -121,10 +121,9 @@ var initMasterKey = exports.initMasterKey = function(done) {
             }
         } else {
             promptMasterKey(function(err, masterKey) {
-                AV.initialize(currApp.appId, masterKey);
-
-                updateKeys(masterKey, function() {
-                    done(masterKey);
+                updateKeys(masterKey, function(appDetail) {
+                    AV.initialize(currApp.appId, masterKey);
+                    done(masterKey, appDetail.app_key);
                 });
             });
         }
@@ -608,10 +607,6 @@ exports.createNewProject = function(cb) {
 
                 console.log("正在创建项目 ...");
                 AV.initialize(appId, masterKey);
-                var baseUrl = AV.serverURL;
-                if (baseUrl.charAt(baseUrl.length - 1) !== "/") {
-                    baseUrl += "/";
-                }
 
                 fetchAppDetail(appId, masterKey, function(err, appDetail) {
                     try {

--- a/bin/run.js
+++ b/bin/run.js
@@ -47,7 +47,7 @@ exports.setProject = function(project) {
   PROJECT = project;
 };
 
-exports.setCloudPath = function(cloudPath) {
+var setCloudPath = exports.setCloudPath = function(cloudPath) {
   CLOUD_PATH = cloudPath;
 };
 
@@ -89,54 +89,26 @@ exports.deleteMasterKeys = function() {
       console.log("[INFO] 删除 " + leancloudAppKeysFile + " ...");
       fs.truncateSync(leancloudAppKeysFile, 0);
     } catch (err) {
-      if (err.code != 'ENOENT')
+      if (err.code !== 'ENOENT')
         exitWith(err.message);
     }
 
     console.log("[INFO] 清除成功");
 };
 
-var initMasterKey = exports.initMasterKey = function(done) {
-    var currApp = getAppSync();
-
-    var promptMasterKey = function(callback) {
-        promptly.password('请输入应用的 Master Key (可从开发者平台的应用设置里找到): ', function(err, masterKey) {
-            if (!masterKey || masterKey.trim() === '')
-                return exitWith("无效的 Master Key");
-
-            callback(null, masterKey.trim());
-        });
-    };
-
-    var updateKeys = function(masterKey, callback) {
-        fetchAppDetail(currApp.appId, masterKey, function(err, appDetail) {
-            updateMasterKeys(currApp.appId, {
-                masterKey: masterKey,
-                appKey: appDetail.app_key
-            }, {force: true}, callback.bind(null, appDetail));
-        });
-    };
-
-    updateMasterKeys(currApp.appId, {}, function(err, keys) {
-        if (keys.masterKey) {
-            done = done.bind(null, keys.masterKey, keys.appKey);
-
-            AV.initialize(currApp.appId, keys.masterKey);
-
-            if (!keys.appKey) { // 如果没有 appKey (旧版本) 则去查询然后纪录
-                updateKeys(keys.masterKey, done);
-            } else {
-                done();
-            }
-        } else {
-            promptMasterKey(function(err, masterKey) {
-                updateKeys(masterKey, function(appDetail) {
-                    AV.initialize(currApp.appId, masterKey);
-                    done(masterKey, appDetail.app_key);
-                });
-            });
-        }
-    });
+var initAVOSCloudSDK = exports.initAVOSCloudSDK = function(appId, cb) {
+  if (_.isFunction(appId)) {
+      cb = appId;
+      appId = getAppSync().appId;
+  }
+  getKeys(appId, function(err, keys) {
+    if(err) {
+      return exitWith(err.message);
+    }
+    AV.initialize(appId, keys.appKey, keys.masterKey);
+    AV.Cloud.useMasterKey();
+    cb(AV);
+  });
 };
 
 function bucketDomain(bucket) {
@@ -244,7 +216,7 @@ function loopLogs(opsToken, cb) {
 }
 
 exports.deployLocalCloudCode = function (runtimeInfo, cloudPath, deployLog, cb) {
-    initMasterKey(function() {
+    initAVOSCloudSDK(function() {
         console.log("[INFO] 压缩项目文件……");
         var file = path.join(TMP_DIR, new Date().getTime() + '.zip');
         var output = fs.createWriteStream(file);
@@ -298,7 +270,7 @@ exports.deployLocalCloudCode = function (runtimeInfo, cloudPath, deployLog, cb) 
 };
 
 exports.deployGitCloudCode = function (revision, giturl, cb) {
-    initMasterKey(function() {
+    initAVOSCloudSDK(function() {
         util.requestCloud('functions/_ops/deployByCommand', {
             after: revision,
             url: giturl
@@ -329,7 +301,7 @@ function outputStatus(status) {
 }
 
 exports.publishCloudCode = function(cb) {
-    initMasterKey(function() {
+    initAVOSCloudSDK(function() {
         util.requestCloud('functions/_ops/publish', {}, 'POST', {
             success: function(resp) {
                 loopLogs(resp.opsToken, function(err) {
@@ -348,7 +320,7 @@ exports.publishCloudCode = function(cb) {
 };
 
 var queryStatus = exports.queryStatus = function(cb) {
-    initMasterKey(function() {
+    initAVOSCloudSDK(function() {
         util.requestCloud('functions/status', {}, 'GET', {
             success: function(resp) {
                 console.log("项目状态：");
@@ -363,9 +335,9 @@ var queryStatus = exports.queryStatus = function(cb) {
 };
 
 exports.undeployCloudCode = function(cb) {
-    initMasterKey(function() {
+    initAVOSCloudSDK(function() {
         util.requestCloud('functions/undeploy/repo', {}, 'POST', {
-            success: function(resp) {
+            success: function() {
                 console.log("[INFO] 清除成功");
                 queryStatus(cb);
             },
@@ -437,7 +409,14 @@ exports.sendStats = function(cmd) {
                 }
             }
         };
-        util.ajax('POST', 'https://cn.avoscloud.com/1/stats/collect', JSON.stringify(data), function(resp) {}, function(err) {}, 'lu348f5799fc5u3eujpzn23acmxy761kq6soyovjc3k6kwrs', 'nrit4mhmqzm1euc3n3k9fv3w0wo72v1bdic6tfrl2usxix3e');
+        util.ajax(
+            'POST',
+            'https://cn.avoscloud.com/1/stats/collect',
+            JSON.stringify(data),
+            function() {},
+            function() {},
+            'lu348f5799fc5u3eujpzn23acmxy761kq6soyovjc3k6kwrs',
+            'nrit4mhmqzm1euc3n3k9fv3w0wo72v1bdic6tfrl2usxix3e');
     } catch (err) {
         //ignore
     }
@@ -452,7 +431,7 @@ function outputLogs(resp) {
 }
 
 exports.viewCloudLog = function (lines, tailf, lastLogUpdatedTime, cb) {
-    initMasterKey(function() {
+    initAVOSCloudSDK(function() {
         var doViewCloudLog = function doViewCloudLog(lines, tailf, lastLogUpdatedTime, cb) {
             var url = 'classes/_CloudLog?order=-updatedAt&limit=' + (lastLogUpdatedTime ? 1000 : (lines || 10));
             if (lastLogUpdatedTime) {
@@ -553,8 +532,6 @@ function updateMasterKeys(appId, keys, options, callback) {
         options = {};
     }
 
-    var leancloudFolder = path.join(getUserHome(), '.leancloud');
-
     loadLocalAppKeys(function(err, appKeys) {
         // If the master key is exists and force is false, then return the eixsts master key
         if (appKeys[appId] && appKeys[appId].masterKey && !options.force)
@@ -565,6 +542,7 @@ function updateMasterKeys(appId, keys, options, callback) {
             appKey: keys.appKey
         };
 
+        var leancloudFolder = path.join(getUserHome(), '.leancloud');
         fs.mkdir(leancloudFolder, '0700', function(err) {
             if (err && err.code != 'EEXIST')
                 return exitWith(err.message);
@@ -582,6 +560,37 @@ function updateMasterKeys(appId, keys, options, callback) {
     });
 }
 
+function getKeys(appId, cb) {
+  loadLocalAppKeys(function(err, appKeys) {
+    if(err) {
+      return exitWith(err.message);
+    }
+
+    var fetchAndUpdateKeys = function(masterKey, cb) {
+      fetchAppDetail(appId, masterKey, function(err, appDetail) {
+        updateMasterKeys(appId, {
+          masterKey: masterKey,
+          appKey: appDetail.app_key
+        }, {force: true}, cb);
+      });
+    };
+
+    var keys = appKeys[appId];
+    if(!keys) {
+      promptly.password('请输入应用的 Master Key (可从开发者平台的应用设置里找到): ', function(err, masterKey) {
+        if (!masterKey || masterKey.trim() === '') {
+            return exitWith("无效的 Master Key");
+        }
+        fetchAndUpdateKeys(masterKey.trim(), cb);
+      });
+    } else if(keys.appKey) {
+      cb(null, keys);
+    } else {
+      fetchAndUpdateKeys(keys.masterKey, cb);
+    }
+  });
+}
+
 /**
  *Creaet a new avoscloud cloud code project.
  */
@@ -592,13 +601,7 @@ exports.createNewProject = function(cb) {
             return exitWith("无效的 Application ID");
 
         appId = appId.trim();
-
-        promptly.password("请输入应用的 Master Key: ", function(err, masterKey) {
-            if (!masterKey || masterKey.trim() === '')
-                return exitWith("无效的 Master Key");
-
-            masterKey = masterKey.trim();
-
+        initAVOSCloudSDK(appId, function(AV) {
             var languagesMapping = {
                 'nodejs': 'node-js-getting-started',
                 'node': 'node-js-getting-started',
@@ -615,9 +618,8 @@ exports.createNewProject = function(cb) {
                     return exitWith("无效的语言");
 
                 console.log("正在创建项目 ...");
-                AV.initialize(appId, masterKey);
 
-                fetchAppDetail(appId, masterKey, function(err, appDetail) {
+                fetchAppDetail(AV.applicationId, AV.masterKey, function(err, appDetail) {
                     try {
                         fs.mkdirSync(appDetail.app_name);
                     } catch (err) {
@@ -637,19 +639,15 @@ exports.createNewProject = function(cb) {
                                 });
 
                                 unzipper.extractAllTo(appDetail.app_name, true);
+
+                                setCloudPath(path.resolve(appDetail.app_name));
+                                addApp(appDetail.app_name, appId);
+                                checkoutApp(appDetail.app_name);
+                                console.log('项目创建完成！');
+                                cb();
                             } catch (err) {
                                 console.error('解压缩文件失败：%s，服务器响应：%s', err.message, fs.readFileSync(zipFilePath, 'utf-8'));
                             }
-
-                            updateMasterKeys(appId, {
-                                masterKey: masterKey,
-                                appKey: appDetail.app_key
-                            }, {force: true}, function() {
-                                exports.setCloudPath(path.resolve(appDetail.app_name));
-                                exports.addApp(appDetail.app_name, appId);
-                                console.log('项目创建完成！');
-                                cb();
-                            });
                         });
                 });
             });
@@ -711,49 +709,15 @@ function importFile(f, realPath, cb) {
  * import files to avoscloud.
  */
 exports.importFiles = function (files, cb) {
-    async.eachLimit(files, IMPORT_FILE_BATCH_SIZE, function(f, cb) {
-        var realPath = path.resolve(f);
-        if (fs.existsSync(realPath)) {
-            importFile(f, realPath, cb);
-        } else {
-            cb(f + " 不存在，忽略");
-        }
-    }, cb);
-};
-
-var initAVOSCloudSDK = exports.initAVOSCloudSDK = function (done) {
-    var currApp = getAppSync();
-    var globalConfig = path.join(CLOUD_PATH, 'config/global.json');
-    if (fs.existsSync(globalConfig)) { // TODO 不需要从 global 文件初始化 AV 对象
-        //try to initialize avoscloud sdk with config/gloabl.json
-        var data = JSON.parse(fs.readFileSync(globalConfig, {
-            encoding: 'utf-8'
-        }));
-        if (data && data.applicationId === currApp.appId)
-            AV.initialize(data.applicationId, data.applicationKey);
-    }
-    initMasterKey(function(masterKey) {
-        if (fs.existsSync(globalConfig)) {
-            //try to initialize avoscloud sdk.
-            var data = JSON.parse(fs.readFileSync(globalConfig, {
-                encoding: 'utf-8'
-            }));
-            if (data && data.applicationId === currApp.appId) {
-                if (masterKey) {
-                    AV._initialize(data.applicationId, data.applicationKey, masterKey);
-                    AV.Cloud.useMasterKey();
-                } else {
-                    AV.initialize(data.applicationId, data.applicationKey);
-                }
+    initAVOSCloudSDK(function() {
+        async.eachLimit(files, IMPORT_FILE_BATCH_SIZE, function(f, cb) {
+            var realPath = path.resolve(f);
+            if (fs.existsSync(realPath)) {
+                importFile(f, realPath, cb);
+            } else {
+                cb(f + " 不存在，忽略");
             }
-        } else {
-          if(masterKey) {
-            AV.initialize(AV.applicationId, AV.applicationKey, masterKey);
-            AV.Cloud.useMasterKey();
-          }
-        }
-        if (done)
-            done(masterKey);
+        }, cb);
     });
 };
 
@@ -866,7 +830,7 @@ var fetchAppDetail = function(appId, masterKey, callback) {
   });
 };
 
-exports.addApp = function(name, appId) {
+var addApp = exports.addApp = function(name, appId) {
     if (!/\w+/.test(name))
         return exitWith("无效的应用名");
     if (!/[a-zA-Z0-9]+/.test(appId))
@@ -887,7 +851,7 @@ exports.removeApp = function(name) {
     console.log("[INFO] 移除应用关联：%s", name);
 };
 
-exports.checkoutApp = function(name) {
+var checkoutApp = exports.checkoutApp = function(name) {
     var apps = getAppsSync();
     if (!apps[name])
         return exitWith("应用 '" + name + "' 不存在");
@@ -1088,6 +1052,7 @@ exports.doLint = function(cb) {
     var cmd = path.join(__dirname, '..', 'node_modules', 'jshint', 'bin', 'jshint') + ' . --exclude node_modules';
     exec(cmd, function(err, stdout, stderr) {
         console.log(stdout);
+        console.log(stderr);
         if (err) {
             process.exit(err.code);
         } else {

--- a/bin/run.js
+++ b/bin/run.js
@@ -86,6 +86,12 @@ exports.deleteMasterKeys = function() {
     try {
       console.log("[INFO] 删除 " + avoscloudKeysFile + " ...");
       fs.truncateSync(avoscloudKeysFile, 0);
+    } catch (err) {
+      if (err.code !== 'ENOENT')
+        exitWith(err.message);
+    }
+
+    try {
       console.log("[INFO] 删除 " + leancloudAppKeysFile + " ...");
       fs.truncateSync(leancloudAppKeysFile, 0);
     } catch (err) {

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -49,7 +49,7 @@ var getCloudCodeRuntimeInfo = function(appPath, cb) {
 
 var getNodeRuntimeInfo = function(appPath, cb) {
   var app = run.getAppSync();
-  run.initMasterKey(function(masterKey) {
+  run.initMasterKey(function(masterKey, appKey) {
     var exec = 'node';
     var script = 'server.js';
     var packageFile = path.join(appPath, 'package.json');
@@ -77,7 +77,7 @@ var getNodeRuntimeInfo = function(appPath, cb) {
           ],
           "env": {
             LC_APP_ID: app.appId,
-            LC_APP_KEY: masterKey,
+            LC_APP_KEY: appKey,
             LC_APP_MASTER_KEY: masterKey,
             LC_APP_PORT: run.getPort()
           },
@@ -95,7 +95,7 @@ var getNodeRuntimeInfo = function(appPath, cb) {
 
 var getPythonRuntimeInfo = function(appPath, cb) {
   var app = run.getAppSync();
-  run.initMasterKey(function(masterKey) {
+  run.initMasterKey(function(masterKey, appKey) {
     cb(null, {
       runtime: 'python',
       exec: 'python',
@@ -112,7 +112,7 @@ var getPythonRuntimeInfo = function(appPath, cb) {
           ],
           "env": {
             LC_APP_ID: app.appId,
-            LC_APP_KEY: masterKey,
+            LC_APP_KEY: appKey,
             LC_APP_MASTER_KEY: masterKey,
             LC_APP_PORT: run.getPort()
           },

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -49,7 +49,7 @@ var getCloudCodeRuntimeInfo = function(appPath, cb) {
 
 var getNodeRuntimeInfo = function(appPath, cb) {
   var app = run.getAppSync();
-  run.initMasterKey(function(masterKey, appKey) {
+  run.initAVOSCloudSDK(function(AV) {
     var exec = 'node';
     var script = 'server.js';
     var packageFile = path.join(appPath, 'package.json');
@@ -77,8 +77,8 @@ var getNodeRuntimeInfo = function(appPath, cb) {
           ],
           "env": {
             LC_APP_ID: app.appId,
-            LC_APP_KEY: appKey,
-            LC_APP_MASTER_KEY: masterKey,
+            LC_APP_KEY: AV.applicationKey,
+            LC_APP_MASTER_KEY: AV.masterKey,
             LC_APP_PORT: run.getPort()
           },
           ext: 'js json coffee',
@@ -95,7 +95,7 @@ var getNodeRuntimeInfo = function(appPath, cb) {
 
 var getPythonRuntimeInfo = function(appPath, cb) {
   var app = run.getAppSync();
-  run.initMasterKey(function(masterKey, appKey) {
+  run.initAVOSCloudSDK(function(AV) {
     cb(null, {
       runtime: 'python',
       exec: 'python',
@@ -112,8 +112,8 @@ var getPythonRuntimeInfo = function(appPath, cb) {
           ],
           "env": {
             LC_APP_ID: app.appId,
-            LC_APP_KEY: appKey,
-            LC_APP_MASTER_KEY: masterKey,
+            LC_APP_KEY: AV.applicationKey,
+            LC_APP_MASTER_KEY: AV.masterKey,
             LC_APP_PORT: run.getPort()
           },
           ext: 'py',

--- a/lib/util.js
+++ b/lib/util.js
@@ -78,7 +78,7 @@ exports.requestRedis = function(server, db, command, cb) {
   });
 };
 
-var ajax = function(method, url, data, success, error, appId, appKey) {
+var ajax = function(method, url, data, success, error, appId, appKey, masterKey) {
     var options = {
         success: success,
         error: error
@@ -116,6 +116,9 @@ var ajax = function(method, url, data, success, error, appId, appKey) {
     }
     if(appKey || AV.applicationKey) {
         xhr.setRequestHeader("X-AVOSCloud-Application-Key", appKey || AV.applicationKey);
+    }
+    if(masterKey || AV.masterKey) {
+        xhr.setRequestHeader("X-AVOSCloud-Master-Key", masterKey || AV.masterKey);
     }
     if (AV._isNode) {
         // Add a special user agent just for request from node.js.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "cookie-signature": "1.0.1",
     "cron": "latest",
     "debug": "0.7.4",
-    "decompress-zip": "0.1.0",
     "ejs": "0.8.4",
     "express": "3.4.0",
     "express-ejs-layouts": "0.3.1",


### PR DESCRIPTION
* [x] 需要先合并 https://github.com/leancloud/avoscloud-code-command/pull/95

`migrateAvoscloudKeys` 用于将原路径的原格式文件迁移到新路径的新格式，为了储存 appKey, 格式从 `{appId: masterKey}` 改为了 `{appId: {appKey, masterKey}}`.