### PR TITLE
修复 Node.js 程序的调试模式无法工作的问题

### DIFF
--- a/bin/avoscloud
+++ b/bin/avoscloud
@@ -219,25 +219,30 @@ if(CMD) {
     if (err) {
       return callback(err);
     }
-    runtimeInfo.setDebug(program.debug);
-    var monconfig = runtimeInfo.getMonconfig(args);
-    console.log(color.green('提示：您可以敲入 rs 命令并回车来重启本进程'));
-    nodemon(monconfig);
-    nodemon.on('restart', function (files) {
-        console.log('[INFO] 因为文件变更而项目重启：', files);
-    });
-    if (runtimeInfo.runtime != 'cloudcode') {
-      run.initAVOSCloudSDK(function(AV) {
-        var app = run.getAppSync();
-        var testServerPort = parseInt(run.getPort()) + 1;
-        testServer.set('leanenginePort', run.getPort());
-        testServer.set('port', testServerPort);
-        testServer.set('appId', app.appId);
-        testServer.set('appKey', AV.applicationKey);
-        testServer.set('masterKey', AV.masterKey);
-        console.log(color.green('提示：您可以使用 http://localhost:' + testServerPort + ' 测试 Cloud 函数'));
-        testServer.listen(testServerPort);
+
+    try {
+      runtimeInfo.setDebug(program.debug);
+      var monconfig = runtimeInfo.getMonconfig(args);
+      console.log(color.green('提示：您可以敲入 rs 命令并回车来重启本进程'));
+      nodemon(monconfig);
+      nodemon.on('restart', function (files) {
+          console.log('[INFO] 因为文件变更而项目重启：', files);
       });
+      if (runtimeInfo.runtime != 'cloudcode') {
+        run.initAVOSCloudSDK(function(AV) {
+          var app = run.getAppSync();
+          var testServerPort = parseInt(run.getPort()) + 1;
+          testServer.set('leanenginePort', run.getPort());
+          testServer.set('port', testServerPort);
+          testServer.set('appId', app.appId);
+          testServer.set('appKey', AV.applicationKey);
+          testServer.set('masterKey', AV.masterKey);
+          console.log(color.green('提示：您可以使用 http://localhost:' + testServerPort + ' 测试 Cloud 函数'));
+          testServer.listen(testServerPort);
+        });
+      }
+    } catch (err) {
+      exitWith(err.message);
     }
   });
 }

--- a/bin/commander.js
+++ b/bin/commander.js
@@ -25,7 +25,7 @@ exports.parse_args = function(argv){
           "cql: 进入 CQL 查询交互。\n    " +
           "redis: LeanCache Redis 命令行。")
       .option('-f, --filepath <path>', '本地云代码项目根路径，默认是当前目录。')
-      .option('-d, --debug', '启用 Debug 模式，参见 https://nodejs.org/api/debugger.html。')
+      .option('-d, --debug', '启用 Debug 模式，参见 https://nodejs.org/api/debugger.html')
       .option('-g, --git', '使用定义在管理平台的 git 仓库或者 -u 指定的 git 仓库部署云代码，默认使用本地代码部署。')
       .option('-p, --project <app>', '命令运行在指定应用上，默认运行在当前应用或者 origin 应用上。')
       .option('-l, --local', '使用本地代码部署云代码，该选项是默认选中。')

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -52,9 +52,10 @@ var getNodeRuntimeInfo = function(appPath, cb) {
   run.initAVOSCloudSDK(function(AV) {
     var exec = 'node';
     var script = 'server.js';
+    var packageObj = {};
     var packageFile = path.join(appPath, 'package.json');
     if(fs.existsSync(packageFile)) {
-      var packageObj = require(packageFile);
+      packageObj = require(packageFile);
       if (packageObj.scripts && packageObj.scripts.start) {
         exec = 'npm';
         script = 'start';
@@ -66,6 +67,12 @@ var getNodeRuntimeInfo = function(appPath, cb) {
       setDebug: function(debug) {
         if (debug) {
           this.exec = 'node debug';
+          if (packageObj.scripts && packageObj.scripts.start) {
+            if (packageObj.scripts.start.match(/^node/))
+              script = packageObj.scripts.start.replace(/^node/, '').trim();
+            else
+              throw new Error('启动调试模式需要 package.json 中 scripts.start 以 node 开头');
+          }
         }
       },
       getMonconfig: function(args) {


### PR DESCRIPTION
https://github.com/leancloud/avoscloud-code-command/issues/97

原因是如果有 package.json 的话会使用 npm 来启动程序，这样就无法启动调试选项了。改成了当启用调试模式时，读取 start script 中的命令，将其中的 node 替换成 node debug, 不过如果 start script 中不是 node 开头就无能为力了。

此外删去了 -d 的选项介绍末尾的中文句号，因为在复制末尾的 URL 的时候很容易不小心将句号复制进来。