### PR TITLE
支持 PHP 项目的部署和本地调试

### DIFF
--- a/lib/router.php
+++ b/lib/router.php
@@ -1,0 +1,7 @@
+<?php
+
+if (file_exists($_SERVER["DOCUMENT_ROOT"] . $_SERVER["REQUEST_URI"])) {
+    return false;
+} else {
+    require "public/index.php";
+}

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -11,6 +11,9 @@ exports.detect = function(appPath, cb) {
   } else if (fs.existsSync(path.join(appPath, 'requirements.txt')) &&
              fs.existsSync(path.join(appPath, 'wsgi.py'))) { // Python
     return getPythonRuntimeInfo(appPath, cb);
+  } else if (fs.existsSync(path.join(appPath, 'composer.json')) &&
+             fs.existsSync(path.join(appPath, 'public/index.php'))) {
+    return getPhpRuntimeInfo(appPath, cb);
   } else {
     cb(new Error('不在 LeanEngine 项目根目录，或目录结构不对。'));
   }
@@ -129,6 +132,33 @@ var getPythonRuntimeInfo = function(appPath, cb) {
       return [{ src: ['**', '!bin/**', '!include/**', '!lib/**', '!pip-selfcheck.json']}];
     }
   });
+};
+
+var getPhpRuntimeInfo = function(appPath, cb) {
+  cb(null, {
+    runtime: 'php',
+    exec: 'php -S 127.0.0.1:3000 -t public',
+    setDebug: function(debug) {
+      if (debug) {
+        console.log('php does not support debug currently');
+      }
+    },
+    getMonconfig: function(args, port) {
+      return {
+        exec: this.exec,
+        ignore: [
+          '.git'
+        ],
+        "env": getCommonEnvironments(AV, port),
+        ext: 'php',
+        script: __dirname + '/router.php',
+        args: args
+      };
+    },
+    bulk: function() {
+      return [{ src: ['**', '!vendor']}];
+    }
+  })
 };
 
 function getCommonEnvironments(AV, port) {


### PR DESCRIPTION
PHP builtin server 因为某种不得而知的原因不会将含有点（`.`）的 Url（而我们的 `/1.1/functions` 里面就有点）转发到 index.php，因此自己添加了一个 `router.php` 实现路由逻辑。

硬编码了一个 3000，因为参数不是很好传，不过感觉关系应该不大。