### PR TITLE
文案修改（avoscloud-code 更名 leanengine-cli）、修复部署时的 --enable 选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,35 +5,33 @@
 安装和更新请使用下列命令：
 
 ```
-sudo npm install -g avoscloud-code
+sudo npm install -g leancloud-cli
 ```
 
 如果从 npm 安装失败，可以从 GitHub 安装：
 
 ```
-sudo npm install -g  git+https://github.com/leancloud/avoscloud-code-command
+sudo npm install -g git+https://github.com/leancloud/avoscloud-code-command
 ```
 
-详细的使用指南见 [云引擎命令行工具使用详解](http://leancloud.cn/docs/cloud_code_commandline.html)，更新日志见 [changelog.md](https://github.com/leancloud/avoscloud-code-command/blob/master/changelog.md)。
+详细的使用指南见 [云引擎命令行工具使用详解](https://leancloud.cn/docs/leanengine_cli.html)，更新日志见 [changelog.md](https://github.com/leancloud/avoscloud-code-command/releases)。
 
 ## 说明
 
 为了方便本地运行和调试云引擎，请遵照下列步骤进行:
 
 * 要在本地调试云引擎，你需要安装 [Node.js](http://nodejs.org) 最新版本。
-* 运行命令：`sudo npm install -g avoscloud-code` 安装调试 SDK。以后更新升级也请执行此命令。
+* 运行命令：`sudo npm install -g leancloud-cli` 来安装命令行工具，以后更新升级也请执行此命令。
 * 在项目根目录运行 `lean up`，将启动本地调试服务器。
 * 访问 [localhost:3000](http://localhost:3000/) 即可访问本机启动的云引擎项目。
 * 访问 [localhost:3001](http://localhost:3001) 调试云引擎函数和 class hook 函数等。
-  * 云引擎 2.0 版访问 [localhost:3000/avos](http://localhost:3000/avos)
 
 ## 功能说明
 
 `lean -h` 输出：
 
 ```
-  Usage: lean [options] [command]
-
+  Usage: lean [command] [options]
 
   Commands:
 
@@ -81,10 +79,13 @@ source ~/.avoscloud_completion.sh
 
 部署、发布等命令在第一次运行的时候要求输入应用的 master key，您可以在 LeanCloud 平台的应用设置里找到 master key。输入后，命令行工具会将这个应用信息记录在 `~/.leancloud/app_keys` 中（0600 文件权限模式）。如果您在认证过程中出现问题，或在公共机器上使用命令行工具，可运行 `lean clear` 来删除认证信息。
 
-
 ## 开发备注
 
-* 发布版本时请同时向 NPM 上 avoscloud-code-command 和 leancloud-cli 这两个包名 publish。
+发布版本时：
+
+* 请同时向 NPM 上 avoscloud-code 和 leancloud-cli 这两个包名 publish
+* 注意为新版本添加 git tag, 并将更新内容填写到 `changelog.md` 和 GitHub 的 Release 页面。
+* 修改用于自动更新的 `latest.version` 并上传到服务器。
 
 ## 贡献者
 

--- a/bin/lean
+++ b/bin/lean
@@ -62,7 +62,7 @@ program
   .option('-r, --revision <revision|branch>', 'git 的版本号或分支，仅对从 git 仓库部署有效。', 'master')
   .option('--noCache [false]', '构建时不使用缓存，使构建总是下载最新的依赖。', false)
   .option('--app <app>', '命令运行在指定应用上，默认运行在当前应用或者 origin 应用上。')
-  .option('--enable <feature1,feature2>', '启用实验性功能。')
+  .option('--enable <option1=xx>,<option2=oo>', '启用实验性功能。')
   .action(function(options) {
     if (options.app) {
       run.setCurrentApp(options.app);

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,11 +1,5 @@
 #!/usr/bin/env node
 'use strict';
-/**
- * AVOS Cloud command-line tool
- * Author: dennis zhuang<xzhuang@avoscloud.com>
- * Project: https://github.com/avoscloud/avoscloud-code-command
- * Created by : Emacs JavaScript Mode
- */
 var path = require('path');
 var fs = require('fs');
 var archiver = require('archiver');
@@ -32,6 +26,8 @@ var debug = require('debug')('lean');
 var Runtime = require('../lib/runtime');
 var util = require('../lib/util');
 
+var pkg = require('../package.json');
+
 //set qiniu timeout
 qiniu.conf.RPC_TIMEOUT = 3600000;
 
@@ -41,8 +37,6 @@ var TMP_DIR = os.tmpdir();
 if (!TMP_DIR.match(/.*\/$/)) {
     TMP_DIR = TMP_DIR + path.sep;
 }
-
-var version = require('../package.json').version;
 
 var APP = null;
 var CLOUD_PATH = path.resolve('.');
@@ -819,10 +813,10 @@ exports.sendStats = function(cmd) {
         var data = {
             appId: 'lu348f5799fc5u3eujpzn23acmxy761kq6soyovjc3k6kwrs',
             device: {
-                sdk_version: version,
+                sdk_version: pkg.version,
                 os_version: (os.platform() + ' ' + os.arch() + ' ' + os.release()),
                 device_id: getDeviceId(),
-                app_version: version,
+                app_version: pkg.version,
                 device_model: os.platform(),
                 os: 'ios'
             },
@@ -1435,8 +1429,8 @@ exports.queryLatestVersion = function(){
     }
     var latestVersion = body.version;
     var changelog = body.changelog || '1.内部重构';
-    if(semver.gt(latestVersion, version)){
-      console.warn(color.green("[WARN] 发现新版本 %s, 变更如下:\n%s\n您可以通过下列命令升级： sudo npm install -g avoscloud-code"), latestVersion, changelog);
+    if(semver.gt(latestVersion, pkg.version)){
+      console.warn(color.green("[WARN] 发现新版本 %s, 变更如下:\n%s\n您可以通过下列命令升级： sudo npm install -g " + pkg.name), latestVersion, changelog);
     }
   });
 };

--- a/bin/run.js
+++ b/bin/run.js
@@ -599,12 +599,12 @@ var deployLocalCloudCodeV4 = function(options, cb) {
     fileId = args[1];
     return Q.nfcall(util.request, 'functions/_ops/groups/' + group.groupName + '/buildAndDeploy', {
       method: 'POST',
-      data: {
+      data: _.extend({
         zipUrl: args[0],
         comment: options.log,
         noDependenciesCache: JSON.parse(options.noCache),
         async: true
-      }
+      }, parseEneableOptions(options.enable))
     });
   }).then(function(data) {
     return Q.nfcall(pollEvents, data.eventToken);
@@ -658,12 +658,12 @@ var deployGitCloudCodeV4 = function(options, cb) {
       }
       return Q.nfcall(util.request, 'functions/_ops/groups/' + group.groupName + '/buildAndDeploy', {
         method: 'POST',
-        data: {
+        data: _.extend({
           comment: options.log,
           noDependenciesCache: JSON.parse(options.noCache),
           gitTag: options.revision,
           async: true
-        }
+        }, parseEneableOptions(options.enable))
       });
     });
   }).then(function(data) {
@@ -1610,3 +1610,21 @@ var logProjectHome = function () {
         console.log('运行方案：%s', color.green(ENGINE_INFO.mode === 'free' ? '免费版' : '专业版'));
     }
 };
+
+function parseEneableOptions(enable) {
+  var result = {};
+
+  if (enable) {
+    var options = enable.split(/\s*,\s*/);
+
+    options.forEach(function(option) {
+      var matched = option.match(/^([^\s\=]+)=(.*)/);
+
+      if (matched) {
+        result[matched[1]] = matched[2];
+      }
+    });
+  }
+
+  return result;
+}


### PR DESCRIPTION
https://github.com/leancloud/cloud-code/issues/916

将 CHANGELOG 的链接改到了 GitHub 的 Release 页面，感觉这个页面漂亮些，发布时记得打 Tag 并同步更新 Release 页面。