### PR TITLE
解决部分中国区应用被识别为美国区的问题

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -1044,7 +1044,7 @@ function getKeys(appId, cb) {
         var result = JSON.parse(body);
         apiServer = 'https://' + result.api_server;
 
-        if (util.API_HOST.us.indexOf(result.api_server) != -1) {
+        if (util.API_HOST.us == 'https://' + result.api_server) {
           region = 'us';
         }
 


### PR DESCRIPTION
之前的代码中，https://us-api.leancloud.cn 会匹配 api.leancloud.cn